### PR TITLE
Git+ssh url support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ pip-install-privates --token <my-token> requirements.txt
 usage: install.py [-h] [--token TOKEN] req_file
 
 Install all requirements from specified file with pip. Optionally transform
-editable URL's to private repo's to use a given Personal Access Token for
+git+git and git+ssh url to private repo's to use a given Personal Access Token for
 github. That way installing them does not depend on a ssh-agent with suitable
 keys. Which you don't have when installing requirements in a Docker.
 These URLs will also be stripped of the -e flag, so they're installed globally.
+Note the -e flag is optional for the git+git//github.com and git+ssh://github.com
+urls.
 
 This means that the following URL:
   -e git+git@github.com:MyOrg/my-project.git@my-tag#egg=my_project

--- a/pipprivates/install.py
+++ b/pipprivates/install.py
@@ -70,10 +70,12 @@ def install():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""
 Install all requirements from specified file with pip. Optionally transform
-editable URL's to private repo's to use a given Personal Access Token for
+git+git and git+ssh url to private repo's to use a given Personal Access Token for
 github. That way installing them does not depend on a ssh-agent with suitable
 keys. Which you don't have when installing requirements in a Docker.
 These URLs will also be stripped of the -e flag, so they're installed globally.
+Note the -e flag is optional for the git+git//github.com and git+ssh://github.com
+urls.
 
 This means that the following URL:
   -e git+git@github.com:MyOrg/my-project.git@my-tag#egg=my_project

--- a/pipprivates/install.py
+++ b/pipprivates/install.py
@@ -5,6 +5,14 @@ import pip
 from pip.status_codes import SUCCESS
 
 
+def convert_url(url, token=None):
+    if token:
+        if url.startswith('git+ssh://git@github.com/'):
+            return 'git+https://{}:x-oauth-basic@github.com/{}'.format(token, url[25:])
+        elif url.startswith('git+git@github.com:'):
+            return 'git+https://{}:x-oauth-basic@github.com/{}'.format(token, url[19:])
+    return url
+
 def collect_requirements(fname, transform_with_token=None):
     with open(fname) as reqs:
         contents = reqs.readlines()
@@ -22,13 +30,12 @@ def collect_requirements(fname, transform_with_token=None):
         #   alembic>=0.8
         #   alembic==0.8.8
         #   alembic==0.8.8  # so we can apply Hypernode/ByteDB fixtures
-        #   git+ssh://github.com/myself/myproject
+        #   git+git://github.com/myself/myproject
         #   git+ssh://github.com/myself/myproject@v2
         #
         if len(tokens) == 1 or tokens[1].startswith('#'):
-            if tokens[0].startswith('git+ssh://git@github.com/') and transform_with_token:
-                collected.append('git+https://{}:x-oauth-basic@github.com/{}'.format(
-                    transform_with_token, tokens[0][25:]))
+            if tokens[0].startswith('git+') and transform_with_token:
+                convert_url(tokens[0], transform_with_token)
             else:
                 collected.append(tokens[0])
 
@@ -43,10 +50,9 @@ def collect_requirements(fname, transform_with_token=None):
         # Rewrite private repositories that normally would use ssh (with keys in an agent), to using
         # an oauth key
         elif tokens[0] == '-e':
-            if tokens[1].startswith('git+git@github.com:'):
+            if tokens[1].startswith('git+'):
                 if transform_with_token:
-                    collected.append('git+https://{}:x-oauth-basic@github.com/{}'.format(
-                        transform_with_token, tokens[1][19:]))
+                    collected.append(convert_url(tokens[1], transform_with_token))
                 else:
                     collected.append('-e {}'.format(tokens[1]))
             else:

--- a/pipprivates/install.py
+++ b/pipprivates/install.py
@@ -33,7 +33,7 @@ def collect_requirements(fname, transform_with_token=None):
         #   git+ssh://github.com/myself/myproject@v2
         #
         if len(tokens) == 1 or tokens[1].startswith('#'):
-            if tokens[0].startswith('git+') and transform_with_token:
+            if (tokens[0].startswith('git+ssh') or tokens[0].startswith('git+git')) and transform_with_token:
                 collected.append(convert_url(tokens[0], transform_with_token))
             else:
                 collected.append(tokens[0])
@@ -49,7 +49,7 @@ def collect_requirements(fname, transform_with_token=None):
         # Rewrite private repositories that normally would use ssh (with keys in an agent), to using
         # an oauth key
         elif tokens[0] == '-e':
-            if tokens[1].startswith('git+'):
+            if tokens[1].startswith('git+ssh') or tokens[1].startswith('git+git'):
                 if transform_with_token:
                     collected.append(convert_url(tokens[1], transform_with_token))
                 else:

--- a/pipprivates/install.py
+++ b/pipprivates/install.py
@@ -26,9 +26,9 @@ def collect_requirements(fname, transform_with_token=None):
         #   git+ssh://github.com/myself/myproject@v2
         #
         if len(tokens) == 1 or tokens[1].startswith('#'):
-            if tokens[0].startswith('git+ssh://github.com/') and transform_with_token:
+            if tokens[0].startswith('git+ssh://git@github.com/') and transform_with_token:
                 collected.append('git+https://{}:x-oauth-basic@github.com/{}'.format(
-                    transform_with_token, tokens[1][21:]))
+                    transform_with_token, tokens[0][25:]))
             else:
                 collected.append(tokens[0])
 

--- a/pipprivates/install.py
+++ b/pipprivates/install.py
@@ -22,8 +22,16 @@ def collect_requirements(fname, transform_with_token=None):
         #   alembic>=0.8
         #   alembic==0.8.8
         #   alembic==0.8.8  # so we can apply Hypernode/ByteDB fixtures
+        #   git+ssh://github.com/myself/myproject
+        #   git+ssh://github.com/myself/myproject@v2
+        #
         if len(tokens) == 1 or tokens[1].startswith('#'):
-            collected.append(tokens[0])
+            if tokens[0].startswith('git+ssh://github.com/') and transform_with_token:
+                collected.append('git+https://{}:x-oauth-basic@github.com/{}'.format(
+                    transform_with_token, tokens[1][21:]))
+            else:
+                collected.append(tokens[0])
+
 
         # Handles:
         #   -r base.txt

--- a/pipprivates/install.py
+++ b/pipprivates/install.py
@@ -34,7 +34,7 @@ def collect_requirements(fname, transform_with_token=None):
         #
         if len(tokens) == 1 or tokens[1].startswith('#'):
             if tokens[0].startswith('git+') and transform_with_token:
-                convert_url(tokens[0], transform_with_token)
+                collected.append(convert_url(tokens[0], transform_with_token))
             else:
                 collected.append(tokens[0])
 

--- a/pipprivates/install.py
+++ b/pipprivates/install.py
@@ -5,12 +5,11 @@ import pip
 from pip.status_codes import SUCCESS
 
 
-def convert_url(url, token=None):
-    if token:
-        if url.startswith('git+ssh://git@github.com/'):
-            return 'git+https://{}:x-oauth-basic@github.com/{}'.format(token, url[25:])
-        elif url.startswith('git+git@github.com:'):
-            return 'git+https://{}:x-oauth-basic@github.com/{}'.format(token, url[19:])
+def convert_url(url, token):
+    if url.startswith('git+ssh://git@github.com/'):
+        return 'git+https://{}:x-oauth-basic@github.com/{}'.format(token, url[25:])
+    elif url.startswith('git+git@github.com:'):
+        return 'git+https://{}:x-oauth-basic@github.com/{}'.format(token, url[19:])
     return url
 
 def collect_requirements(fname, transform_with_token=None):

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -74,6 +74,12 @@ class TestInstall(TestCase):
         self.assertEqual(ret, ['git+https://github.com/ByteInternet/...'])
 
     def test_transforms_vcs_git_url_to_oauth(self):
+        fname = self._create_reqs_file(['git+git@github.com:ByteInternet/...'])
+
+        ret = collect_requirements(fname, transform_with_token='my-token')
+        self.assertEqual(ret, ['git+https://my-token:x-oauth-basic@github.com/ByteInternet/...'])
+
+    def test_transforms_vcs_git_url_to_oauth_dashe_option(self):
         fname = self._create_reqs_file(['-e git+git@github.com:ByteInternet/...'])
 
         ret = collect_requirements(fname, transform_with_token='my-token')
@@ -81,6 +87,12 @@ class TestInstall(TestCase):
 
     def test_transforms_vcs_ssh_url_to_oauth(self):
         fname = self._create_reqs_file(['git+ssh://git@github.com/ByteInternet/...'])
+
+        ret = collect_requirements(fname, transform_with_token='my-token')
+        self.assertEqual(ret, ['git+https://my-token:x-oauth-basic@github.com/ByteInternet/...'])
+
+    def test_transforms_vcs_ssh_url_to_oauth_dashe_option(self):
+        fname = self._create_reqs_file(['-e git+ssh://git@github.com/ByteInternet/...'])
 
         ret = collect_requirements(fname, transform_with_token='my-token')
         self.assertEqual(ret, ['git+https://my-token:x-oauth-basic@github.com/ByteInternet/...'])

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -73,8 +73,14 @@ class TestInstall(TestCase):
         ret = collect_requirements(fname)
         self.assertEqual(ret, ['git+https://github.com/ByteInternet/...'])
 
-    def test_transforms_vcs_ssh_url_to_oauth(self):
+    def test_transforms_vcs_git_url_to_oauth(self):
         fname = self._create_reqs_file(['-e git+git@github.com:ByteInternet/...'])
+
+        ret = collect_requirements(fname, transform_with_token='my-token')
+        self.assertEqual(ret, ['git+https://my-token:x-oauth-basic@github.com/ByteInternet/...'])
+
+    def test_transforms_vcs_ssh_url_to_oauth(self):
+        fname = self._create_reqs_file(['git+ssh://git@github.com/ByteInternet/...'])
 
         ret = collect_requirements(fname, transform_with_token='my-token')
         self.assertEqual(ret, ['git+https://my-token:x-oauth-basic@github.com/ByteInternet/...'])


### PR DESCRIPTION
Support url schema `git+ssh` and optional `-e` for `git+ssh` and `git+git` urls.

cf https://pip.pypa.io/en/stable/reference/pip_install/#git