### PR TITLE
don't build PR branches twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  - master
+
 language: python
 python:
   - 2.7


### PR DESCRIPTION
For example, this PR has 2 builds which are the same: https://github.com/ByteInternet/pip-install-privates/pull/11

That's unnecessary.