### PR TITLE
Fix install with pip 18.1

### DIFF
--- a/pip_install_privates/install.py
+++ b/pip_install_privates/install.py
@@ -1,10 +1,21 @@
 #!/usr/bin/env python
 import argparse
 import os
-try:
-    from pip import status_codes, main as pip_main
-except ImportError:
+from pip import __version__ as pip_version
+
+from pip_install_privates.utils import parse_pip_version
+
+pip_version_tuple = parse_pip_version(pip_version)
+gte_18_1 = pip_version_tuple[0] == 18 and pip_version_tuple[1] >= 1
+if pip_version_tuple[0] > 18 or gte_18_1:
+    from pip._internal import main as pip_main
+    from pip._internal.cli import status_codes
+
+elif pip_version_tuple[0] >= 10:
     from pip._internal import status_codes, main as pip_main
+
+else:
+    from pip import status_codes, main as pip_main
 
 
 def convert_url(url, token):

--- a/pip_install_privates/utils.py
+++ b/pip_install_privates/utils.py
@@ -1,0 +1,7 @@
+def parse_pip_version(version_string):
+    return tuple(
+        map(
+            int,
+            version_string.split('.')
+        )
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py34
     py35
     py36
+    py37
 
 [testenv]
 deps = -rrequirements.txt
@@ -25,4 +26,8 @@ commands = nosetests
 
 [testenv:py36]
 basepython = python3.6
+commands = nosetests
+
+[testenv:py37]
+basepython = python3.7
 commands = nosetests


### PR DESCRIPTION
Pip 18.1 moved status_codes from _internal to _internal.cli.

We now parse the pip version and select imports accordingly. This is a
little heavy-handed, but avoids having nested try-except ImportError
clauses and is a bit more extensible if pip can't decide where to keep
status_codes again in future ;)