### PR TITLE
Use GITHUB_TOKEN environment var if defined

### DIFF
--- a/pip_install_privates/install.py
+++ b/pip_install_privates/install.py
@@ -100,7 +100,8 @@ are also stripped of the -e flag. If no token is given, private URLs will be
 kept, including the -e flag (otherwise they can't be installed at all).
 """)
 
-    parser.add_argument('--token', '-t', help='Your Personal Access Token for private GitHub repositories')
+    parser.add_argument('--token', '-t', help='Your Personal Access Token for private GitHub repositories',
+                        default=os.environ.get('GITHUB_TOKEN'))
     parser.add_argument('req_file', help='path to the requirements file to install')
     args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readfile(filename):
 
 setup(
     name='pip_install_privates',
-    version='0.5.1',
+    version='0.5.2',
     description='Install pip packages from private repositories without an ssh agent',
     long_description=readfile('README.rst'),
     long_description_content_type='text/x-rst',

--- a/tests/unit/test_commandline.py
+++ b/tests/unit/test_commandline.py
@@ -40,6 +40,21 @@ class TestCommandLine(TestCase):
         self.mock_collect.assert_called_once_with('requirements.txt',
                                                   transform_with_token='my-token')
 
+    def test_uses_github_token_environment_variable_if_no_token_supplied(self):
+        with patch.dict('pip_install_privates.install.os.environ', {'GITHUB_TOKEN': 'my-token'}):
+            with patch.object(sys, 'argv', ['pip-install', 'requirements.txt']):
+                install()
+
+        self.mock_collect.assert_called_once_with('requirements.txt',
+                                                  transform_with_token='my-token')
+
+    def test_uses_none_if_no_token_supplied_and_no_github_token_defined_as_environment_variable(self):
+        with patch.object(sys, 'argv', ['pip-install', 'requirements.txt']):
+            install()
+
+        self.mock_collect.assert_called_once_with('requirements.txt',
+                                                  transform_with_token=None)
+
     def test_commandline_requires_requirements_file(self):
         with patch('sys.stderr', new_callable=StringIO):
             with patch.object(sys, 'argv', ['pip-install']):


### PR DESCRIPTION
If no token is provided as an arg look for the `GITHUB_TOKEN` environment variable and use that instead.
If there's no environment variable defined we continue as usual.

Fixes #18 