### PR TITLE
Also convert git+https to oauth token urls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readfile(filename):
 
 setup(
     name='pip_install_privates',
-    version='0.5.3',
+    version='0.5.4',
     description='Install pip packages from private repositories without an ssh agent',
     long_description=readfile('README.rst'),
     long_description_content_type='text/x-rst',

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -119,4 +119,34 @@ class TestInstall(TestCase):
                                '-e', 'git+https://github.com/ByteInternet/...',
                                'nose==1.3.7', 'fso==0.3.1'])
 
+    def test_transforms_git_plus_https_urls_to_https_url_with_oauth_token_if_token_provided(self):
+        file1 = self._create_reqs_file(['mock==2.0.0', 'git+https://github.com/ByteInternet/...', 'nose==1.3.7'])
+        fname = self._create_reqs_file(['-r {}'.format(file1), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname, transform_with_token='my-token')
+
+        self.assertEqual(ret, ['mock==2.0.0',
+                               'git+https://my-token:x-oauth-basic@github.com/ByteInternet/...',
+                               'nose==1.3.7', 'fso==0.3.1'])
+
+    def test_transforms_editable_git_plus_https_urls_to_editable_https_url_with_oauth_token_if_token_provided(self):
+        file1 = self._create_reqs_file(['mock==2.0.0', '-e git+https://github.com/ByteInternet/...', 'nose==1.3.7'])
+        fname = self._create_reqs_file(['-r {}'.format(file1), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname, transform_with_token='my-token')
+
+        self.assertEqual(ret, ['mock==2.0.0',
+                               '-e', 'git+https://my-token:x-oauth-basic@github.com/ByteInternet/...',
+                               'nose==1.3.7', 'fso==0.3.1'])
+
+    def test_does_not_transform_git_plus_https_urls_to_https_url_with_oauth_token_if_no_token_provided(self):
+        file1 = self._create_reqs_file(['mock==2.0.0', '-e git+https://github.com/ByteInternet/...', 'nose==1.3.7'])
+        fname = self._create_reqs_file(['-r {}'.format(file1), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname)
+
+        self.assertEqual(ret, ['mock==2.0.0',
+                               '-e', 'git+https://github.com/ByteInternet/...',
+                               'nose==1.3.7', 'fso==0.3.1'])
+
 


### PR DESCRIPTION
Previously it was assumed that git+https URLs would be public, but this is of course not always true.
So now also make sure that git+https urls are converted to an oauth URL if a token is provided.

Should fix issue #19 