### PR TITLE
Allow pip environment markers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readfile(filename):
 
 setup(
     name='pip_install_privates',
-    version='0.6.0',
+    version='0.6.1',
     description='Install pip packages from private repositories without an ssh agent',
     long_description=readfile('README.rst'),
     long_description_content_type='text/x-rst',

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -149,4 +149,72 @@ class TestInstall(TestCase):
                                '-e', 'git+https://github.com/ByteInternet/...',
                                'nose==1.3.7', 'fso==0.3.1'])
 
+    def test_transforms_editable_requirement_with_pip_environment_marker_to_github_url_with_token(self):
+        file = self._create_reqs_file([
+            'mock==2.0.0',
+            "-e 'git+https://github.com/ByteInternet/... ; python_version==\"2.7\"'",
+            'nose==1.3.7'
+        ])
+        fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname, transform_with_token=True)
+
+        self.assertEqual(ret, [
+            'mock==2.0.0',
+            '-e', 'git+https://True:x-oauth-basic@github.com/ByteInternet/... ; python_version=="2.7"',
+            'nose==1.3.7',
+            'fso==0.3.1'
+        ])
+
+    def test_transforms_editable_requirement_with_pip_environment_marker_to_github_url_without_token(self):
+        file = self._create_reqs_file([
+            'mock==2.0.0',
+            "-e 'git+https://github.com/ByteInternet/... ; python_version==\"2.7\"'",
+            'nose==1.3.7'
+        ])
+        fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname)
+
+        self.assertEqual(ret, [
+            'mock==2.0.0',
+            '-e', 'git+https://github.com/ByteInternet/... ; python_version=="2.7"',
+            'nose==1.3.7',
+            'fso==0.3.1'
+        ])
+
+    def test_transforms_editable_requirement_with_pip_environment_marker_if_cannot_convert_to_url(self):
+        file = self._create_reqs_file([
+            'mock==2.0.0',
+            "-e 'banana+https://github.com/ByteInternet/... ; python_version==\"2.7\"'",
+            'nose==1.3.7'
+        ])
+        fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname)
+
+        self.assertEqual(ret, [
+            'mock==2.0.0',
+            '-e', 'banana+https://github.com/ByteInternet/... ; python_version=="2.7"',
+            'nose==1.3.7',
+            'fso==0.3.1'
+        ])
+
+    def test_transform_requirement_if_pip_environment_marker_in_tokens(self):
+        file = self._create_reqs_file([
+            'mock==2.0.0',
+            "myrequirement==1.3.3.7 ; python_version==\"3.7\"",
+            'nose==1.3.7'
+        ])
+        fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname)
+
+        self.assertEqual(ret, [
+            'mock==2.0.0',
+            'myrequirement==1.3.3.7 ; python_version=="3.7"',
+            'nose==1.3.7',
+            'fso==0.3.1'
+        ])
+
 


### PR DESCRIPTION
Handle pip environment markers correctly. These allow you to specify a
certain requirement for a certain environment and looks like:
```
my-requirement==0.1.2 ; python_version=="3.7"
```
or
```
-e 'git+git@github.com:ByteInternet/my-repo.git@20201127.1#egg=my-repo ; python_version=="3.7"'
```
Notice that we can both handle regular and editable/custom
requirements. Tested with an example requirements file that had several
combinations of this, and it works (only installs that one specified in
the requirements based on the environment).