### PR TITLE
Do not break on inline comments with environment markers

### DIFF
--- a/pip_install_privates/install.py
+++ b/pip_install_privates/install.py
@@ -118,19 +118,19 @@ def collect_requirements(fname, transform_with_token=None):
                     flag, github_url = convert_to_editable_github_url_with_token(
                         stripped_tokens[1], transform_with_token)
 
-                    github_url = add_potential_pip_environment_markers_to_url(stripped_tokens, github_url)
+                    github_url = add_potential_pip_environment_markers_to_requirement(stripped_tokens, github_url)
                     collected += [flag, github_url]
                 else:
                     flag, github_url = convert_to_editable_github_url(stripped_tokens[1])
 
-                    github_url = add_potential_pip_environment_markers_to_url(stripped_tokens, github_url)
+                    github_url = add_potential_pip_environment_markers_to_requirement(stripped_tokens, github_url)
                     collected += [flag, github_url]
             else:
-                url = add_potential_pip_environment_markers_to_url(stripped_tokens, stripped_tokens[1])
+                url = add_potential_pip_environment_markers_to_requirement(stripped_tokens, stripped_tokens[1])
                 collected += ['-e', url]
 
         elif ';' in tokens:
-            collected += [' '.join(tokens)]
+            collected += [add_potential_pip_environment_markers_to_requirement(tokens, tokens[0])]
 
         # No special casing for the rest. Just pass everything to pip
         else:
@@ -139,23 +139,23 @@ def collect_requirements(fname, transform_with_token=None):
     return collected
 
 
-def add_potential_pip_environment_markers_to_url(stripped_tokens, url):
+def add_potential_pip_environment_markers_to_requirement(stripped_tokens, requirement):
     """
     :param stripped_tokens: A list of tokens for the install requirement, without any single quotes (this can be present
     in cases where an editable requirement is specified with environment markers). I.e.:
     -e 'git+git@github.com:ByteInternet/my-repo.git@20201127.1#egg=my-repo ; python_version=="3.7"'
 
-    :param url: The github URL of the editable requirement.
+    :param requirement: The requirement. I.e. 'mock==2.0.0' or git+git@github.com:ByteInternet/repo.git@1.1.1#egg=repo
 
     :return: The github URL of the editable requirement with the pip environment marker appended.
     """
     try:
         pip_environment_marker_index = stripped_tokens.index(';')
     except ValueError:
-        return url
+        return requirement
 
     environment_index = pip_environment_marker_index + 1
-    return '{} ; {}'.format(url, stripped_tokens[environment_index])
+    return '{} ; {}'.format(requirement, stripped_tokens[environment_index])
 
 
 def install():

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -166,10 +166,44 @@ class TestInstall(TestCase):
             'fso==0.3.1'
         ])
 
+    def test_transforms_editable_requirement_with_pip_environment_marker_inline_comment_to_github_url_with_token(self):
+        file = self._create_reqs_file([
+            'mock==2.0.0',
+            "-e 'git+https://github.com/ByteInternet/... ; python_version==\"2.7\"'  # We need this because reasons",
+            'nose==1.3.7'
+        ])
+        fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname, transform_with_token=True)
+
+        self.assertEqual(ret, [
+            'mock==2.0.0',
+            '-e', 'git+https://True:x-oauth-basic@github.com/ByteInternet/... ; python_version=="2.7"',
+            'nose==1.3.7',
+            'fso==0.3.1'
+        ])
+
     def test_transforms_editable_requirement_with_pip_environment_marker_to_github_url_without_token(self):
         file = self._create_reqs_file([
             'mock==2.0.0',
             "-e 'git+https://github.com/ByteInternet/... ; python_version==\"2.7\"'",
+            'nose==1.3.7'
+        ])
+        fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname)
+
+        self.assertEqual(ret, [
+            'mock==2.0.0',
+            '-e', 'git+https://github.com/ByteInternet/... ; python_version=="2.7"',
+            'nose==1.3.7',
+            'fso==0.3.1'
+        ])
+
+    def test_transforms_editable_requirement_with_pip_environment_marker_inline_comment_to_github_url_no_token(self):
+        file = self._create_reqs_file([
+            'mock==2.0.0',
+            "-e 'git+https://github.com/ByteInternet/... ; python_version==\"2.7\"'  # We need this because reasons",
             'nose==1.3.7'
         ])
         fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])
@@ -200,10 +234,44 @@ class TestInstall(TestCase):
             'fso==0.3.1'
         ])
 
-    def test_transform_requirement_if_pip_environment_marker_in_tokens(self):
+    def test_transforms_editable_requirement_with_pip_environment_marker_inline_comment_if_cannot_convert_to_url(self):
+        file = self._create_reqs_file([
+            'mock==2.0.0',
+            "-e 'banana+https://github.com/ByteInternet/... ; python_version==\"2.7\"'  # We need this because reasons",
+            'nose==1.3.7'
+        ])
+        fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname)
+
+        self.assertEqual(ret, [
+            'mock==2.0.0',
+            '-e', 'banana+https://github.com/ByteInternet/... ; python_version=="2.7"',
+            'nose==1.3.7',
+            'fso==0.3.1'
+        ])
+
+    def test_transforms_requirement_if_pip_environment_marker_in_tokens(self):
         file = self._create_reqs_file([
             'mock==2.0.0',
             "myrequirement==1.3.3.7 ; python_version==\"3.7\"",
+            'nose==1.3.7'
+        ])
+        fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])
+
+        ret = collect_requirements(fname)
+
+        self.assertEqual(ret, [
+            'mock==2.0.0',
+            'myrequirement==1.3.3.7 ; python_version=="3.7"',
+            'nose==1.3.7',
+            'fso==0.3.1'
+        ])
+
+    def test_transforms_requirement_if_pip_environment_marker_in_tokens_with_inline_comment(self):
+        file = self._create_reqs_file([
+            'mock==2.0.0',
+            "myrequirement==1.3.3.7 ; python_version==\"3.7\"  # We need this because reasons",
             'nose==1.3.7'
         ])
         fname = self._create_reqs_file(['-r {}'.format(file), 'fso==0.3.1'])


### PR DESCRIPTION
This already worked for the editable requirements, but not for regular
requirements with environment markers (we just pasted all the token
together, but if there was a comment in there we would accidentally act
like that was part of the requirement). So just make sure we use the
same function in all cases which neatly appends the environment marker.

Also added some tests for this for safety's sake.