### PR TITLE
New feature to use project names and root dir to target private github urls 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,23 @@ Usage
 
 Run ``pip_install_privates --help`` for more information.
 
+Environment Variables
+---------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Variable
+     - Description
+   * - ``GITHUB_TOKEN``
+     - Your Personal Access Token for GitHub. Used for accessing private GitHub repositories.
+   * - ``GITLAB_TOKEN`` or ``CI_JOB_TOKEN``
+     - Your Personal Access Token for GitLab. Used for accessing private GitLab repositories.
+   * - ``GITLAB_DOMAIN``
+     - The domain of your custom GitLab instance, if not using the standard ``gitlab.com``.
+   * - ``GITHUB_ROOT_DIR``
+     - The base directory on GitHub that will be transformed when using the ``#pip-private`` tag. Helps in mapping URLs from GitHub to GitLab.
+
 To use `pip_install_privates`, you need a Personal Access Token from GitHub or GitLab.
 
 GitHub
@@ -54,7 +71,7 @@ GitLab
 6. Input the path to the group or project to add to the allowlist, and select "Add project".
 7. This will be used with `CI_JOB_TOKEN`.
 
-GitLab Domain
+GitLab Domain, 
 -------------
 
 When using a custom domain:
@@ -66,7 +83,22 @@ When using a custom domain:
 
     export GITLAB_DOMAIN=your.gitlab.domain
 
-Running the Script
+New Feature: Handling #pip-private Tag
+---------------------------------------
+
+Use the `#pip-private` tag in your `requirements.txt` to automatically convert GitHub URLs to private GitLab URLs during installation:
+
+.. code-block:: plaintext
+
+    git+ssh://git@github.com/ByteInternet/my-project.git@my_tag#egg=my_project #pip-private
+
+This URL will be transformed to use the specified `CI_JOB_TOKEN`, `GITHUB_ROOT_DIR` and `GITLAB_DOMAIN`:
+
+.. code-block:: plaintext
+
+    git+https://gitlab-ci-token:token@your.gitlab.domain/projectDir/my-project.git@my_tag#egg=my_project
+
+Ensure you set `CI_JOB_TOKEN`, `GITLAB_DOMAIN`, and `GITHUB_ROOT_DIR` for accurate URL conversion.\Running the Script
 ------------------
 
 If using a custom GitLab domain, ensure your `requirements.txt` or `base.txt` contains the domain variable you wish to mask. Example below:
@@ -75,6 +107,7 @@ If using a custom GitLab domain, ensure your `requirements.txt` or `base.txt` co
 
     git+https://${GITLAB_DOMAIN}/your-repo.git@20240227.1#egg=your-repo
     git+https://github.com/your_org/your_repo.git@v1.0.0#egg=your_package
+    git+https://github.com/your_org/your_repo.git@v1.0.0#egg=your_package #pip-private
 
 Run the script with the token:
 

--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,9 @@ Environment Variables
    * - ``GITLAB_DOMAIN``
      - The domain of your custom GitLab instance, if not using the standard ``gitlab.com``.
    * - ``GITHUB_ROOT_DIR``
-     - The base directory on GitHub that will be transformed
+     - The base directory on GitHub that will be transformed.
    * - ``PROJECT_NAMES``
-     - comma-separated list of project names used to identify which GitHub URLs should be transformed to GitLab URLs. 
+     - Comma-separated list of project names used to identify which GitHub URLs should be transformed to GitLab URLs.
 
 To use `pip_install_privates`, you need a Personal Access Token from GitHub or GitLab.
 
@@ -90,42 +90,28 @@ Handling GitHub to GitLab URL Transformation
 
 Use `GITHUB_ROOT_DIR` and `PROJECT_NAMES` environment variables to automatically convert GitHub URLs to private GitLab URLs during installation.
 
-### GITHUB_ROOT_DIR
-
-`GITHUB_ROOT_DIR` specifies the base directory on GitHub that the script will transform when applying the private tag. It acts as a root folder in URL transformations.
-
-### PROJECT_NAMES
-
-`PROJECT_NAMES` is a comma-separated list of project names used to identify which GitHub URLs should be transformed to GitLab URLs. If a URL in the `requirements.txt` file contains any of the specified project names and starts with the specified `GITHUB_ROOT_DIR`, it will be transformed.
+- `GITHUB_ROOT_DIR` specifies the base directory on GitHub that the script will transform when applying the private tag. It acts as a root folder in URL transformations.
+- `PROJECT_NAMES` is a comma-separated list of project names used to identify which GitHub URLs should be transformed to GitLab URLs. If a URL in the `requirements.txt` file contains any of the specified project names and starts with the specified `GITHUB_ROOT_DIR`, it will be transformed.
 
 Example:
 - GitHub URL: `git+ssh://git@github.com/ByteInternet/my-project.git@my_tag#egg=my_project`
 - GITHUB_ROOT_DIR: `ByteInternet`
-- GITHUB_DOMAIN `your.gitlab.domain/root`
+- GITLAB_DOMAIN: `your.gitlab.domain`
 - PROJECT_NAMES: `my-project,my-other-project`
-
-- Transformed GitLab URL: `git+https://gitlab-ci-token:token@your.gitlab.domain/root/ByteInternet/my-project.git@my_tag#egg=my_project`
-
-Execute the script with the following
-
-Example:
-- PROJECT_NAMES: `my-project,my-other-project`
-- Requirement: `git+ssh://git@github.com/ByteInternet/my-project.git@my_tag#egg=my_project`
 - Transformed GitLab URL: `git+https://gitlab-ci-token:token@your.gitlab.domain/ByteInternet/my-project.git@my_tag#egg=my_project`
 
-Execute the script with the following
+Execute the script with the following:
 
-.. code-block:: bash 
-    pip_install_privates --gitlab-token ${CI_JOB_TOKEN} --gitlab-domain ${{GITLAB_DOMAIN} --github-root-dir ${GITHUB_ROOT_DIR} --project-names ${PROJECT_NAMES} requirements/development.txt Running the Script
+.. code-block:: bash
 
-Ensure your `requirements.txt` or `base.txt` contains the necessary URLs.
+    pip_install_privates --gitlab-token ${CI_JOB_TOKEN} --gitlab-domain ${GITLAB_DOMAIN} --github-root-dir ${GITHUB_ROOT_DIR} --project-names ${PROJECT_NAMES} requirements/development.txt
 
 GitHub with token
 -----------------
 
 .. code-block:: bash
-    git+ssh://git@github.com/your_org/your_repo.git@v1.0.0#egg=your_package
 
+    git+ssh://git@github.com/your_org/your_repo.git@v1.0.0#egg=your_package
 
 Run the script with the token:
 

--- a/pip_install_privates/install.py
+++ b/pip_install_privates/install.py
@@ -108,7 +108,7 @@ def convert_to_gitlab_url(url, gitlab_domain=None):
         if url.startswith(prefix):
             transformed_url = f"git+https://{domain}/{url[len(prefix):]}"
             logger.debug(
-                f"Transformed {transformed_url} GitLab URL to git+https URL without using an OAuth token"
+                f"Transformed {url} GitLab URL to git+https URL without using an OAuth token"
             )
             return transformed_url
     return url
@@ -176,7 +176,7 @@ def convert_potential_git_url(
         else:
             git_url = convert_to_github_url(requirement)
         git_url = add_potential_pip_environment_markers_to_requirement(tokens, git_url)
-        logger.debug(f"Converted potential Git URL: {git_url}")
+        logger.debug(f"Converted potential Git URL: {requirement}")
         return [git_url]
     return [add_potential_pip_environment_markers_to_requirement(tokens, requirement)]
 
@@ -476,10 +476,7 @@ def install():
     github_root_dir = args.github_root_dir or os.environ.get("GITHUB_ROOT_DIR")
     project_names = args.project_names or os.environ.get("PROJECT_NAMES")
 
-    logger.debug(
-        f"Arguments received: token={args.token}, gitlab_token={ci_job_token}, gitlab_domain={gitlab_domain}, github_root_dir={github_root_dir}, project_names={project_names}"
-    )
-
+    
     pip_args = ["install"] + collect_requirements(
         args.req_file,
         transform_with_token=args.token,

--- a/pip_install_privates/install.py
+++ b/pip_install_privates/install.py
@@ -210,7 +210,6 @@ def collect_requirements(
     ci_job_token=None,
     github_root_dir=None,
     project_names=None,
-    no_auth=False,
 ):
     """
     Collect and transform requirements from a file.
@@ -242,9 +241,7 @@ def collect_requirements(
         # Early transform check before any other processing
         if "github.com/" in original_line:
             for proj in project_names:
-                logger.debug(f"proj is: {proj}")
-                logger.debug(f"project names is: {project_names}")
-                if proj and f"github.com/{github_root_dir}/{proj}" in original_line:
+                if proj in original_line:
                     logger.debug(f"Line before GitHub to GitLab transform: {original_line}")
                     logger.debug(f"proj is: {proj}")
                     line = transform_github_to_gitlab(
@@ -254,8 +251,10 @@ def collect_requirements(
                         github_root_dir,
                         project_names,
                     )
-                    logger.debug(f"Line after GitHub to GitLab transform: {line}")
-                    break  # Exit the loop once a transformation has been done
+                else: 
+                    line = convert_to_github_url(original_line)
+                logger.debug(f"Line after transformation: {line}")
+                break  # Exit the loop once a transformation has been done
         else:
             line = original_line
 
@@ -310,6 +309,8 @@ def collect_requirements(
                             tokens[0], transform_with_token
                         )
                     )
+                elif not transform_with_token:
+                    collected.append(convert_to_github_url(tokens[0]))
                 else:
                     collected.append(tokens[0])
             else:
@@ -361,7 +362,6 @@ def collect_requirements(
             collected += tokens
 
     return collected
-
 
 
 def transform_github_to_gitlab(

--- a/pip_install_privates/install.py
+++ b/pip_install_privates/install.py
@@ -243,6 +243,11 @@ def collect_requirements(
                         collected.append(
                             convert_to_gitlab_url(tokens[0], gitlab_domain)
                         )
+                elif "github.com/" in line and "#pip-private" in line:
+                    line = transform_github_to_gitlab(
+                    line, ci_job_token, gitlab_domain, github_root_dir
+            )
+                
                 elif transform_with_token:
                     collected.append(
                         convert_to_github_url_with_token(

--- a/tests/unit/test_commandline.py
+++ b/tests/unit/test_commandline.py
@@ -34,6 +34,8 @@ class TestCommandLine(TestCase):
             transform_with_token=None,
             gitlab_domain=None,
             ci_job_token=None,
+            github_root_dir=None,
+            project_names=None,
         )
 
     def test_commandline_passes_specified_token_to_collect(self):
@@ -47,6 +49,8 @@ class TestCommandLine(TestCase):
             transform_with_token="my-token",
             gitlab_domain=None,
             ci_job_token=None,
+            github_root_dir=None,
+            project_names=None,
         )
 
     def test_uses_github_token_environment_variable_if_no_token_supplied(self):
@@ -61,6 +65,8 @@ class TestCommandLine(TestCase):
             transform_with_token="my-token",
             gitlab_domain=None,
             ci_job_token=None,
+            github_root_dir=None,
+            project_names=None,
         )
 
     def test_uses_none_if_no_token_supplied_and_no_github_token_defined_as_environment_variable(
@@ -74,6 +80,8 @@ class TestCommandLine(TestCase):
             transform_with_token=None,
             gitlab_domain=None,
             ci_job_token=None,
+            github_root_dir=None,
+            project_names=None,
         )
 
     def test_commandline_requires_requirements_file(self):
@@ -112,6 +120,8 @@ class TestCommandLine(TestCase):
             transform_with_token="my-token",
             gitlab_domain="my.gitlab.com",
             ci_job_token="CI-token",
+            github_root_dir=None,
+            project_names=None,
         )
 
     def test_uses_gitlab_domain_environment_variable_if_defined(self):
@@ -127,4 +137,43 @@ class TestCommandLine(TestCase):
             transform_with_token=None,
             gitlab_domain="my.gitlab.com",
             ci_job_token="CI-token",
+            github_root_dir=None,
+            project_names=None,
+        )
+
+    def test_commandline_with_all_arguments(self):
+        with patch.dict(
+            "pip_install_privates.install.os.environ",
+            {
+                "CI_JOB_TOKEN": "env_ci_job_token",
+                "GITLAB_DOMAIN": "env.gitlab.com",
+                "GITHUB_ROOT_DIR": "env_github_root_dir",
+                "PROJECT_NAMES": "env_project1,env_project2",
+            },
+        ):
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "pip-install",
+                    "--gitlab-token",
+                    "arg_ci_job_token",
+                    "--gitlab-domain",
+                    "arg.gitlab.com",
+                    "--github-root-dir",
+                    "arg_github_root_dir",
+                    "--project-names",
+                    "arg_project1,arg_project2",
+                    "requirements/development.txt",
+                ],
+            ):
+                install()
+
+        self.mock_collect.assert_called_once_with(
+            "requirements/development.txt",
+            transform_with_token=None,
+            gitlab_domain="arg.gitlab.com",
+            ci_job_token="arg_ci_job_token",
+            github_root_dir="arg_github_root_dir",
+            project_names="arg_project1,arg_project2",
         )

--- a/tests/unit/test_gitlab_url_conversion.py
+++ b/tests/unit/test_gitlab_url_conversion.py
@@ -235,5 +235,3 @@ class TestGitLabURLConversion(unittest.TestCase):
                     github_root_dir=github_root_dir,
                 )
                 self.assertEqual(result, expected)
-                
-                

--- a/tests/unit/test_gitlab_url_conversion.py
+++ b/tests/unit/test_gitlab_url_conversion.py
@@ -215,12 +215,12 @@ class TestGitLabURLConversion(unittest.TestCase):
         github_token = None
         gitlab_domain = "group.company/root"
         github_root_dir = "ByteInternet"
-        project_name = "my-project2"
+        project_name = "my-project2, my-project"
         requirements = [
-            "git+https://github.com/ByteInternet/my-project2.git@my-tag#egg=my_project",
+            "git+ssh://git@github.com/ByteInternet/my-project2.git",
         ]
         expected = [
-            "git+https://gitlab-ci-token:token@group.company/root/my-project2.git@my-tag#egg=my_project",
+            "git+https://gitlab-ci-token:token@group.company/root/my-project2.git",
         ]
 
         with patch(

--- a/tests/unit/test_gitlab_url_conversion.py
+++ b/tests/unit/test_gitlab_url_conversion.py
@@ -5,6 +5,7 @@ from pip_install_privates.install import (
     convert_to_gitlab_url_with_token,
     collect_requirements,
     convert_potential_git_url,
+    transform_github_to_gitlab,
 )
 
 
@@ -190,17 +191,34 @@ class TestGitLabURLConversion(unittest.TestCase):
             )
             self.assertEqual(result, expected)
 
+    def test_convert_to_gitlab_with_private_comment(self):
+        gitlab_token = "token"
+        gitlab_domain = "group.team.blue/hypernode"
+        github_root_dir = "ByteInternet"
+        requirement = "git+ssh://git@github.com/ByteInternet/my-project.git@my-tag#egg=my_project #pip-private"
+
+        expected = "git+https://gitlab-ci-token:token@group.team.blue/hypernode/my-project.git@my-tag#egg=my_project"
+
+        with patch("builtins.open", new_callable=mock_open, read_data=requirement):
+            result = transform_github_to_gitlab(
+                line=requirement,
+                ci_job_token=gitlab_token,
+                gitlab_domain=gitlab_domain,
+                github_root_dir=github_root_dir,
+            )
+            self.assertEqual(result, expected)
+
     def test_editable_gitlab_url_with_token(self):
         fname = "requirements.txt"
         gitlab_token = "token"
         github_token = None
-        gitlab_domain = None
+        gitlab_domain = "group.team.blue/hypernode"
+        github_root_dir = "ByteInternet"
         requirements = [
-            "-e git+git@gitlab.com:MyOrg/my-project.git@my-tag#egg=my_project",
+            "git+https://github.com/ByteInternet/my-project.git@my-tag#egg=my_project #pip-private",
         ]
         expected = [
-            "-e",
-            "git+https://gitlab-ci-token:token@gitlab.com/MyOrg/my-project.git@my-tag#egg=my_project",
+            "git+https://gitlab-ci-token:token@group.team.blue/hypernode/my-project.git@my-tag#egg=my_project",
         ]
 
         with patch(
@@ -211,6 +229,7 @@ class TestGitLabURLConversion(unittest.TestCase):
                 gitlab_domain=gitlab_domain,
                 ci_job_token=gitlab_token,
                 transform_with_token=github_token,
+                github_root_dir=github_root_dir,
             )
             self.assertEqual(result, expected)
 

--- a/tests/unit/test_gitlab_url_conversion.py
+++ b/tests/unit/test_gitlab_url_conversion.py
@@ -193,11 +193,11 @@ class TestGitLabURLConversion(unittest.TestCase):
 
     def test_convert_to_gitlab_with_private_comment(self):
         gitlab_token = "token"
-        gitlab_domain = "group.team.blue/hypernode"
+        gitlab_domain = "group.company/root"
         github_root_dir = "ByteInternet"
         requirement = "git+ssh://git@github.com/ByteInternet/my-project.git@my-tag#egg=my_project #pip-private"
 
-        expected = "git+https://gitlab-ci-token:token@group.team.blue/hypernode/my-project.git@my-tag#egg=my_project"
+        expected = "git+https://gitlab-ci-token:token@group.company/root/my-project.git@my-tag#egg=my_project"
 
         with patch("builtins.open", new_callable=mock_open, read_data=requirement):
             result = transform_github_to_gitlab(
@@ -212,13 +212,38 @@ class TestGitLabURLConversion(unittest.TestCase):
         fname = "requirements.txt"
         gitlab_token = "token"
         github_token = None
-        gitlab_domain = "group.team.blue/hypernode"
+        gitlab_domain = "group.company/root"
         github_root_dir = "ByteInternet"
         requirements = [
             "git+https://github.com/ByteInternet/my-project.git@my-tag#egg=my_project #pip-private",
         ]
         expected = [
-            "git+https://gitlab-ci-token:token@group.team.blue/hypernode/my-project.git@my-tag#egg=my_project",
+            "git+https://gitlab-ci-token:token@group.company/root/my-project.git@my-tag#egg=my_project",
+        ]
+
+        with patch(
+            "builtins.open", new_callable=mock_open, read_data="\n".join(requirements)
+        ):
+            result = collect_requirements(
+                fname,
+                gitlab_domain=gitlab_domain,
+                ci_job_token=gitlab_token,
+                transform_with_token=github_token,
+                github_root_dir=github_root_dir,
+            )
+            self.assertEqual(result, expected)
+            
+    def test_editable_gitlab_url_root_dir_and_ssh(self):
+        fname = "requirements.txt"
+        gitlab_token = "token"
+        github_token = None
+        gitlab_domain = "group.company/root"
+        github_root_dir = "ByteInternet"
+        requirements = [
+            "git+ssh://git@github.com/ByteInternet/my-project.git@my-tag#egg=my_project #pip-private",
+        ]
+        expected = [
+            "git+https://gitlab-ci-token:token@group.company/root/my-project.git@my-tag#egg=my_project",
         ]
 
         with patch(

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -617,3 +617,29 @@ class TestInstall(TestCase):
                 "fso==0.3.1",
             ],
         )
+
+    def test_transforms_gitlab_git_url(self):
+        file = self._create_reqs_file(
+            [
+                "git+ssh://git@github.com/ByteInternet/my-project.git@my-tag#egg=my_project",
+            ]
+        )
+        fname = self._create_reqs_file(["-r {}".format(file), "fso==0.3.1"])
+
+        with patch.dict(
+            "os.environ", {"CI_JOB_TOKEN": "token", "PROJECT_NAMES": "my-project"}
+        ):
+            ret = collect_requirements(
+                fname,
+                gitlab_domain="group.company/root",
+                github_root_dir="ByteInternet",
+                ci_job_token="token",
+            )
+
+        self.assertEqual(
+            ret,
+            [
+                "git+https://gitlab-ci-token:token@group.company/root/my-project.git@my-tag#egg=my_project",
+                "fso==0.3.1",
+            ],
+        )


### PR DESCRIPTION
New feature to use project names and root dir to target private github urls we wish to transform that share common parent and root dir of public we do not want to authenticate with. 