### PR TITLE
Adjustment for multiple project names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,20 +91,20 @@ Handling GitHub to GitLab URL Transformation
 Use `GITHUB_ROOT_DIR` and `PROJECT_NAMES` environment variables to automatically convert GitHub URLs to private GitLab URLs during installation.
 
 - `GITHUB_ROOT_DIR` specifies the base directory on GitHub that the script will transform when applying the private tag. It acts as a root folder in URL transformations.
-- `PROJECT_NAMES` is a comma-separated list of project names used to identify which GitHub URLs should be transformed to GitLab URLs. If a URL in the `requirements.txt` file contains any of the specified project names and starts with the specified `GITHUB_ROOT_DIR`, it will be transformed.
+- `"PROJECT_NAMES"` is a comma-separated list of project names used to identify which GitHub URLs should be transformed to GitLab URLs. If a URL in the `requirements.txt` file contains any of the specified project names and starts with the specified `GITHUB_ROOT_DIR`, it will be transformed.
 
 Example:
 - GitHub URL: `git+ssh://git@github.com/ByteInternet/my-project.git@my_tag#egg=my_project`
 - GITHUB_ROOT_DIR: `ByteInternet`
 - GITLAB_DOMAIN: `your.gitlab.domain`
-- PROJECT_NAMES: `my-project,my-other-project`
+- PROJECT_NAMES: `my-project,my-other-project` # Wrap variable in "" pass in multiple project names on CI.
 - Transformed GitLab URL: `git+https://gitlab-ci-token:token@your.gitlab.domain/ByteInternet/my-project.git@my_tag#egg=my_project`
 
 Execute the script with the following:
 
 .. code-block:: bash
 
-    pip_install_privates --gitlab-token ${CI_JOB_TOKEN} --gitlab-domain ${GITLAB_DOMAIN} --github-root-dir ${GITHUB_ROOT_DIR} --project-names ${PROJECT_NAMES} requirements/development.txt
+    pip_install_privates --gitlab-token ${CI_JOB_TOKEN} --gitlab-domain ${GITLAB_DOMAIN} --github-root-dir ${GITHUB_ROOT_DIR} --project-names "${PROJECT_NAMES}" requirements/development.txt
 
 GitHub with token
 -----------------

--- a/pip_install_privates/install.py
+++ b/pip_install_privates/install.py
@@ -223,6 +223,7 @@ def collect_requirements(
     :param project_names: Comma-separated string of project names to look for in the GitHub URLs.
     :return: A list of collected and transformed requirements.
     """
+
     if project_names is None:
         project_names = os.environ.get("PROJECT_NAMES", "")
     project_names = [proj.strip() for proj in project_names.split(",")]
@@ -240,6 +241,7 @@ def collect_requirements(
         logger.debug(f"Processing line: {original_line}")
 
         # Early transform check before any other processing
+        transformed = False
         if "github.com/" in original_line:
             for proj in project_names:
                 if proj in original_line:
@@ -250,9 +252,10 @@ def collect_requirements(
                         github_root_dir,
                         project_names,
                     )
-                else:
-                    line = convert_to_github_url(original_line)
-                break  # Exit the loop once a transformation has been done
+                    transformed = True
+                    break  # Exit the loop once a transformation has been done
+            if not transformed:
+                line = convert_to_github_url(original_line)
         else:
             line = original_line
 
@@ -476,7 +479,6 @@ def install():
     github_root_dir = args.github_root_dir or os.environ.get("GITHUB_ROOT_DIR")
     project_names = args.project_names or os.environ.get("PROJECT_NAMES")
 
-    
     pip_args = ["install"] + collect_requirements(
         args.req_file,
         transform_with_token=args.token,

--- a/tests/unit/test_gitlab_url_conversion.py
+++ b/tests/unit/test_gitlab_url_conversion.py
@@ -215,12 +215,41 @@ class TestGitLabURLConversion(unittest.TestCase):
         github_token = None
         gitlab_domain = "group.company/root"
         github_root_dir = "ByteInternet"
-        project_name = "my-project2, my-project"
+        project_name = "hypernode-api, my-project2"
         requirements = [
             "git+ssh://git@github.com/ByteInternet/my-project2.git",
         ]
         expected = [
             "git+https://gitlab-ci-token:token@group.company/root/my-project2.git",
+        ]
+
+        with patch(
+            "builtins.open", new_callable=mock_open, read_data="\n".join(requirements)
+        ):
+            with patch.dict("os.environ", {"PROJECT_NAMES": project_name}):
+                result = collect_requirements(
+                    fname,
+                    gitlab_domain=gitlab_domain,
+                    ci_job_token=gitlab_token,
+                    transform_with_token=github_token,
+                    github_root_dir=github_root_dir,
+                )
+                self.assertEqual(result, expected)
+
+    def test_editable_gitlab_url_with_token_and_multiple_project_env_variable(self):
+        fname = "requirements.txt"
+        gitlab_token = "token"
+        github_token = None
+        gitlab_domain = "group.company/root"
+        github_root_dir = "ByteInternet"
+        project_name = "my-project2, byte-api, not-in-req"
+        requirements = [
+            "git+ssh://git@github.com/ByteInternet/my-project2.git",
+            "git+ssh://git@github.com/ByteInternet/byte-api.git",
+        ]
+        expected = [
+            "git+https://gitlab-ci-token:token@group.company/root/my-project2.git",
+            "git+https://gitlab-ci-token:token@group.company/root/byte-api.git",
         ]
 
         with patch(


### PR DESCRIPTION
small adjustment to allow organisation to use multiple project names as a list and added test for this, updated read me to inform user to wrap the env var in quotes to pass the list in on ci.